### PR TITLE
Implement minimal mindmap viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MindMap Minimal
 
 This project is a minimal single-page mind map editor implemented from scratch.
-Open `index.html` in a modern browser to run it. You can add child/sibling nodes,
-remove nodes, drag to pan and use the mouse wheel to zoom.
+Open `index.html` in a modern browser to run it. Click nodes to select them.
+Press **Tab** to add a child or **Enter** to add a sibling. Double-click or hit
+**F2** to edit the selected node, or simply start typing when a node is
+selected. Drag the background to pan and use the mouse wheel to zoom. Branches
+from the root are automatically colored.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# mindmap
+# MindMap Minimal
+
+This project is a minimal single-page mind map editor implemented from scratch.
+Open `index.html` in a modern browser to run it. You can add child/sibling nodes,
+remove nodes, drag to pan and use the mouse wheel to zoom.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@ This project is a minimal single-page mind map editor implemented from scratch.
 Open `index.html` in a modern browser to run it. Click nodes to select them.
 Press **Tab** to add a child or **Enter** to add a sibling. Double-click or hit
 **F2** to edit the selected node, or simply start typing when a node is
-selected. Drag the background to pan and use the mouse wheel to zoom. Branches
-from the root are automatically colored.
+selected. Use the **Image** button to attach a picture to the selected node.
+Click **Save JSON** to download the map with images embedded and **Load JSON**
+to restore a saved file. Drag the background to pan and use the mouse wheel to
+zoom. Branches from the root are automatically colored and children are laid
+out above and below their parent for readability.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,12 @@
         <button id="addChildBtn">Add Child (Tab)</button>
         <button id="addSiblingBtn">Add Sibling (Enter)</button>
         <button id="deleteBtn">Delete (Del)</button>
+        <button id="imageBtn">Image</button>
+        <button id="saveBtn">Save JSON</button>
+        <button id="loadBtn">Load JSON</button>
         <button id="fitBtn">Fit</button>
+        <input type="file" id="imageInput" accept="image/*" style="display:none">
+        <input type="file" id="loadInput" accept="application/json" style="display:none">
     </div>
     <svg id="mindmap" width="100%" height="100%">
         <g id="viewport"></g>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MindMap Minimal</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="toolbar">
+        <button id="newBtn">New</button>
+        <button id="addChildBtn">Add Child (Tab)</button>
+        <button id="addSiblingBtn">Add Sibling (Enter)</button>
+        <button id="deleteBtn">Delete (Del)</button>
+        <button id="fitBtn">Fit</button>
+    </div>
+    <svg id="mindmap" width="100%" height="100%">
+        <g id="viewport"></g>
+    </svg>
+    <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,17 @@
+const NODE_W = 100;
+const NODE_H = 40;
+const V_GAP = 20;
+
+export function layout(map) {
+    let y = 0;
+    function dfs(id, depth) {
+        const node = map.nodes[id];
+        node.x = depth * (NODE_W + 40);
+        node.y = y;
+        node.w = NODE_W;
+        node.h = NODE_H;
+        y += NODE_H + V_GAP;
+        node.children.forEach(childId => dfs(childId, depth + 1));
+    }
+    dfs(map.rootId, 0);
+}

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,17 +1,60 @@
-const NODE_W = 100;
+const NODE_W = 80;
 const NODE_H = 40;
+const H_GAP = 60;
 const V_GAP = 20;
 
 export function layout(map) {
-    let y = 0;
-    function dfs(id, depth) {
+    const heights = {};
+
+    function measure(id) {
         const node = map.nodes[id];
-        node.x = depth * (NODE_W + 40);
-        node.y = y;
-        node.w = NODE_W;
-        node.h = NODE_H;
-        y += NODE_H + V_GAP;
-        node.children.forEach(childId => dfs(childId, depth + 1));
+        node.w = NODE_W + (node.media ? node.media.width + 10 : 0);
+        node.h = Math.max(NODE_H, node.media ? node.media.height + 10 : NODE_H);
+        if (!node.children.length) {
+            heights[id] = node.h;
+            return heights[id];
+        }
+        let total = 0;
+        node.children.forEach(c => {
+            total += measure(c);
+        });
+        total += V_GAP * (node.children.length - 1);
+        heights[id] = Math.max(node.h, total);
+        return heights[id];
     }
-    dfs(map.rootId, 0);
+
+    measure(map.rootId);
+
+    function place(id, depth, centerY) {
+        const node = map.nodes[id];
+        node.x = depth * (NODE_W + H_GAP);
+        node.y = centerY - node.h / 2;
+        if (!node.children.length) return;
+        let total = 0;
+        node.children.forEach(c => total += heights[c]);
+        total += V_GAP * (node.children.length - 1);
+        let start = centerY - total / 2;
+        node.children.forEach(c => {
+            const h = heights[c];
+            const childCenter = start + h / 2;
+            place(c, depth + 1, childCenter);
+            start += h + V_GAP;
+        });
+    }
+
+    place(map.rootId, 0, 0);
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    Object.values(map.nodes).forEach(n => {
+        minX = Math.min(minX, n.x);
+        minY = Math.min(minY, n.y);
+        maxX = Math.max(maxX, n.x + n.w);
+        maxY = Math.max(maxY, n.y + n.h);
+    });
+    const offsetX = -(minX + maxX) / 2;
+    const offsetY = -(minY + maxY) / 2;
+    Object.values(map.nodes).forEach(n => {
+        n.x += offsetX;
+        n.y += offsetY;
+    });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -58,6 +58,7 @@ newBtn.onclick = () => {
     selectedId = map.rootId;
     pan = {x:0,y:0,scale:1};
     update();
+    startEditing(selectedId);
 };
 
 fitBtn.onclick = fitToScreen;
@@ -120,6 +121,9 @@ window.addEventListener('keydown', e => {
     } else if (e.key === 'F2') {
         e.preventDefault();
         startEditing(selectedId);
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        startEditing(selectedId, e.key);
+        e.preventDefault();
     }
 });
 
@@ -134,7 +138,7 @@ viewport.addEventListener('dblclick', e => {
 let editingInput = null;
 let editingId = null;
 
-function startEditing(id) {
+function startEditing(id, initial) {
     if (editingInput) return;
     editingId = id;
     const nodeEl = viewport.querySelector(`.node[data-id="${id}"]`);
@@ -143,11 +147,15 @@ function startEditing(id) {
     editingInput = document.createElement('input');
     editingInput.type = 'text';
     editingInput.className = 'edit-input';
-    editingInput.value = map.nodes[id].text;
+    editingInput.value = initial !== undefined ? initial : map.nodes[id].text;
     positionEditor(bbox);
     document.body.appendChild(editingInput);
     editingInput.focus();
-    editingInput.select();
+    if (initial === undefined) {
+        editingInput.select();
+    } else {
+        editingInput.setSelectionRange(editingInput.value.length, editingInput.value.length);
+    }
     editingInput.addEventListener('keydown', e => {
         if (e.key === 'Enter') {
             finishEditing();

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,117 @@
+import { createEmptyMap, addChild, addSibling, deleteNode } from './model.js';
+import { layout } from './layout.js';
+import { render } from './render.js';
+
+let map = createEmptyMap();
+let selectedId = map.rootId;
+const viewport = document.getElementById('viewport');
+
+let pan = {x:0, y:0, scale:1};
+
+function update() {
+    layout(map);
+    render(map, viewport, selectedId);
+    viewport.setAttribute('transform', `translate(${pan.x},${pan.y}) scale(${pan.scale})`);
+}
+update();
+
+// selection handling
+viewport.addEventListener('click', e => {
+    const g = e.target.closest('.node');
+    if (g) {
+        selectedId = g.dataset.id;
+        update();
+    }
+});
+
+// toolbar actions
+const addChildBtn = document.getElementById('addChildBtn');
+const addSiblingBtn = document.getElementById('addSiblingBtn');
+const deleteBtn = document.getElementById('deleteBtn');
+const newBtn = document.getElementById('newBtn');
+const fitBtn = document.getElementById('fitBtn');
+
+addChildBtn.onclick = () => {
+    const id = addChild(map, selectedId);
+    selectedId = id;
+    update();
+};
+
+addSiblingBtn.onclick = () => {
+    const id = addSibling(map, selectedId);
+    if (id) selectedId = id;
+    update();
+};
+
+deleteBtn.onclick = () => {
+    deleteNode(map, selectedId);
+    selectedId = map.rootId;
+    update();
+};
+
+newBtn.onclick = () => {
+    map = createEmptyMap();
+    selectedId = map.rootId;
+    pan = {x:0,y:0,scale:1};
+    update();
+};
+
+fitBtn.onclick = fitToScreen;
+
+function fitToScreen() {
+    const bbox = viewport.getBBox();
+    const svg = document.getElementById('mindmap');
+    const w = svg.clientWidth;
+    const h = svg.clientHeight;
+    const scale = Math.min(w / (bbox.width + 40), h / (bbox.height + 40));
+    const tx = -bbox.x * scale + (w - bbox.width * scale) / 2;
+    const ty = -bbox.y * scale + (h - bbox.height * scale) / 2;
+    pan = { x: tx, y: ty, scale };
+    update();
+}
+
+// pan and zoom
+let isPanning = false;
+let start = {x:0,y:0};
+
+document.getElementById('mindmap').addEventListener('mousedown', e => {
+    isPanning = true;
+    start = { x: e.clientX - pan.x, y: e.clientY - pan.y };
+});
+
+document.addEventListener('mousemove', e => {
+    if (isPanning) {
+        pan.x = e.clientX - start.x;
+        pan.y = e.clientY - start.y;
+        update();
+    }
+});
+
+document.addEventListener('mouseup', () => {
+    isPanning = false;
+});
+
+document.getElementById('mindmap').addEventListener('wheel', e => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.1 : 0.1;
+    pan.scale = Math.min(2, Math.max(0.25, pan.scale + delta));
+    update();
+});
+
+// keyboard shortcuts
+window.addEventListener('keydown', e => {
+    if (e.target.tagName === 'INPUT') return;
+    if (e.key === 'Tab') {
+        e.preventDefault();
+        addChildBtn.onclick();
+    } else if (e.key === 'Enter') {
+        e.preventDefault();
+        addSiblingBtn.onclick();
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault();
+        deleteBtn.onclick();
+    } else if (e.key === 'f' && e.ctrlKey) {
+        e.preventDefault();
+        fitToScreen();
+    }
+});

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,41 @@
+export function createEmptyMap() {
+    const rootId = 'n1';
+    return {
+        id: 'map-' + Date.now(),
+        title: 'MindMap',
+        rootId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        version: 1,
+        nodes: {
+            [rootId]: { id: rootId, parentId: null, text: 'Root', children: [] }
+        }
+    };
+}
+
+export function addChild(map, parentId) {
+    const id = 'n' + (Object.keys(map.nodes).length + 1);
+    map.nodes[id] = { id, parentId, text: 'Node', children: [] };
+    map.nodes[parentId].children.push(id);
+    map.updatedAt = Date.now();
+    return id;
+}
+
+export function addSibling(map, nodeId) {
+    const parentId = map.nodes[nodeId].parentId;
+    if (parentId === null) return null;
+    return addChild(map, parentId);
+}
+
+export function deleteNode(map, nodeId) {
+    const node = map.nodes[nodeId];
+    if (!node || nodeId === map.rootId) return;
+    const parent = map.nodes[node.parentId];
+    parent.children = parent.children.filter(id => id !== nodeId);
+    function removeSubtree(id) {
+        map.nodes[id].children.forEach(removeSubtree);
+        delete map.nodes[id];
+    }
+    removeSubtree(nodeId);
+    map.updatedAt = Date.now();
+}

--- a/src/model.js
+++ b/src/model.js
@@ -49,3 +49,10 @@ export function deleteNode(map, nodeId) {
     removeSubtree(nodeId);
     map.updatedAt = Date.now();
 }
+
+export function setNodeImage(map, nodeId, media) {
+    const node = map.nodes[nodeId];
+    if (!node) return;
+    if (media) node.media = media; else delete node.media;
+    map.updatedAt = Date.now();
+}

--- a/src/model.js
+++ b/src/model.js
@@ -1,3 +1,5 @@
+const PALETTE = ['#ff6f59', '#f6bd60', '#43aa8b', '#577590', '#d7263d', '#06d6a0'];
+
 export function createEmptyMap() {
     const rootId = 'n1';
     return {
@@ -7,15 +9,23 @@ export function createEmptyMap() {
         createdAt: Date.now(),
         updatedAt: Date.now(),
         version: 1,
+        colorIndex: 0,
         nodes: {
-            [rootId]: { id: rootId, parentId: null, text: 'Root', children: [] }
+            [rootId]: { id: rootId, parentId: null, text: 'Root', children: [], color: '#ffffff' }
         }
     };
 }
 
 export function addChild(map, parentId) {
     const id = 'n' + (Object.keys(map.nodes).length + 1);
-    map.nodes[id] = { id, parentId, text: 'Node', children: [] };
+    let color = '#ffffff';
+    if (parentId === map.rootId) {
+        color = PALETTE[map.colorIndex % PALETTE.length];
+        map.colorIndex++;
+    } else {
+        color = map.nodes[parentId].color;
+    }
+    map.nodes[id] = { id, parentId, text: 'Node', children: [], color };
     map.nodes[parentId].children.push(id);
     map.updatedAt = Date.now();
     return id;

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,27 @@
 export function render(map, svg, selectedId) {
     svg.innerHTML = '';
+    const linkGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    linkGroup.id = 'links';
+    svg.appendChild(linkGroup);
+    const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    nodeGroup.id = 'nodes';
+    svg.appendChild(nodeGroup);
+
+    // draw links
+    Object.values(map.nodes).forEach(node => {
+        if (node.parentId) {
+            const parent = map.nodes[node.parentId];
+            const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            line.classList.add('link');
+            line.setAttribute('x1', parent.x + parent.w);
+            line.setAttribute('y1', parent.y + parent.h / 2);
+            line.setAttribute('x2', node.x);
+            line.setAttribute('y2', node.y + node.h / 2);
+            linkGroup.appendChild(line);
+        }
+    });
+
+    // draw nodes
     for (const id in map.nodes) {
         const node = map.nodes[id];
         const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -19,6 +41,6 @@ export function render(map, svg, selectedId) {
         text.textContent = node.text;
         g.appendChild(text);
 
-        svg.appendChild(g);
+        nodeGroup.appendChild(g);
     }
 }

--- a/src/render.js
+++ b/src/render.js
@@ -33,6 +33,7 @@ export function render(map, svg, selectedId) {
         const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
         rect.setAttribute('width', node.w);
         rect.setAttribute('height', node.h);
+        if (node.color) rect.style.fill = node.color;
         g.appendChild(rect);
 
         const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');

--- a/src/render.js
+++ b/src/render.js
@@ -36,9 +36,21 @@ export function render(map, svg, selectedId) {
         if (node.color) rect.style.fill = node.color;
         g.appendChild(rect);
 
+        let offset = 10;
+        if (node.media && node.media.kind === 'image') {
+            const img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            img.setAttribute('href', node.media.dataUrl);
+            img.setAttribute('width', node.media.width);
+            img.setAttribute('height', node.media.height);
+            img.setAttribute('x', 5);
+            img.setAttribute('y', (node.h - node.media.height) / 2);
+            g.appendChild(img);
+            offset += node.media.width + 5;
+        }
+
         const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        text.setAttribute('x', 10);
-        text.setAttribute('y', 25);
+        text.setAttribute('x', offset);
+        text.setAttribute('y', node.h / 2 + 5);
         text.textContent = node.text;
         g.appendChild(text);
 

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,24 @@
+export function render(map, svg, selectedId) {
+    svg.innerHTML = '';
+    for (const id in map.nodes) {
+        const node = map.nodes[id];
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        g.classList.add('node');
+        g.setAttribute('data-id', id);
+        if (id === selectedId) g.classList.add('selected');
+        g.setAttribute('transform', `translate(${node.x},${node.y})`);
+
+        const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        rect.setAttribute('width', node.w);
+        rect.setAttribute('height', node.h);
+        g.appendChild(rect);
+
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', 10);
+        text.setAttribute('y', 25);
+        text.textContent = node.text;
+        g.appendChild(text);
+
+        svg.appendChild(g);
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,16 @@ body, html {
     stroke: #ff6f59;
     stroke-width: 2px;
 }
+
+.link {
+    stroke: #888;
+    stroke-width: 1.5px;
+}
+
+.edit-input {
+    position: absolute;
+    font-size: 14px;
+    box-sizing: border-box;
+    border: 1px solid #333;
+    padding: 2px;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,30 @@
+body, html {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    font-family: sans-serif;
+}
+#toolbar {
+    padding: 4px;
+    background: #f0f0f0;
+    border-bottom: 1px solid #ccc;
+}
+#mindmap {
+    width: 100%;
+    height: calc(100% - 40px);
+    cursor: grab;
+}
+.node rect {
+    fill: #fff;
+    stroke: #333;
+    rx: 6;
+    ry: 6;
+}
+.node text {
+    pointer-events: none;
+    font-size: 14px;
+}
+.node.selected rect {
+    stroke: #ff6f59;
+    stroke-width: 2px;
+}


### PR DESCRIPTION
## Summary
- build a minimal SPA mindmap editor
- implement simple data model and layout
- allow creating children/siblings and deleting nodes
- add basic pan, zoom and fit-to-screen behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c369c06bc832aa8534b7e85de47b4