### PR TITLE
Improve UI and image viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ and styled with Bootstrap. Open `index.html` in a modern browser to run it.
 Click nodes to select them. Press **Tab** to add a child or **Enter** to add a
 sibling. Double-click or hit **F2** to edit the selected node, or simply start
 typing when a node is selected. Use the **Image** button to attach a picture to
-the selected node. Images can be viewed larger by clicking on them.
+the selected node. Clicking an image opens it almost fullscreen so details are
+easier to see.
 Click **Save JSON** to download the map with images embedded and
 **Load JSON** to restore a saved file. Drag the background to pan and use the
 mouse wheel to zoom. Branches from the root are automatically colored and

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ and styled with Bootstrap. Open `index.html` in a modern browser to run it.
 Click nodes to select them. Press **Tab** to add a child or **Enter** to add a
 sibling. Double-click or hit **F2** to edit the selected node, or simply start
 typing when a node is selected. Use the **Image** button to attach a picture to
-the selected node. Clicking an image shows it centered on screen at the
-resolution stored in the map (up to 256 px on the longest side).
+the selected node. Clicking an image shows it centered on screen at its full
+resolution, scaled down only if it exceeds the browser window.
 Click **Save JSON** to download the map with images embedded and
 **Load JSON** to restore a saved file. Drag the background to pan and use the
 mouse wheel to zoom. Branches from the root are automatically colored and

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ and styled with Bootstrap. Open `index.html` in a modern browser to run it.
 Click nodes to select them. Press **Tab** to add a child or **Enter** to add a
 sibling. Double-click or hit **F2** to edit the selected node, or simply start
 typing when a node is selected. Use the **Image** button to attach a picture to
-the selected node. Clicking an image opens it almost fullscreen so details are
-easier to see.
+the selected node. Clicking an image shows it centered on screen at the
+resolution stored in the map (up to 256 px on the longest side).
 Click **Save JSON** to download the map with images embedded and
 **Load JSON** to restore a saved file. Drag the background to pan and use the
 mouse wheel to zoom. Branches from the root are automatically colored and

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# mindmap
+# MindMap Minimal
+
+This project is a minimal single-page mind map editor implemented from scratch
+and styled with Bootstrap. Open `index.html` in a modern browser to run it.
+Click nodes to select them. Press **Tab** to add a child or **Enter** to add a
+sibling. Double-click or hit **F2** to edit the selected node, or simply start
+typing when a node is selected. Use the **Image** button to attach a picture to
+the selected node. Images can be viewed larger by clicking on them.
+Click **Save JSON** to download the map with images embedded and
+**Load JSON** to restore a saved file. Drag the background to pan and use the
+mouse wheel to zoom. Branches from the root are automatically colored and
+children are laid out above and below their parent for readability.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MindMap Minimal</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="toolbar" class="p-2 bg-light border-bottom d-flex flex-wrap gap-2">
+        <button id="newBtn" class="btn btn-sm btn-secondary">New</button>
+        <button id="addChildBtn" class="btn btn-sm btn-primary">Add Child (Tab)</button>
+        <button id="addSiblingBtn" class="btn btn-sm btn-primary">Add Sibling (Enter)</button>
+        <button id="deleteBtn" class="btn btn-sm btn-danger">Delete (Del)</button>
+        <button id="imageBtn" class="btn btn-sm btn-outline-secondary">Image</button>
+        <button id="saveBtn" class="btn btn-sm btn-outline-secondary">Save JSON</button>
+        <button id="loadBtn" class="btn btn-sm btn-outline-secondary">Load JSON</button>
+        <button id="fitBtn" class="btn btn-sm btn-outline-secondary">Fit</button>
+        <input type="file" id="imageInput" accept="image/*" style="display:none">
+        <input type="file" id="loadInput" accept="application/json" style="display:none">
+    </div>
+    <svg id="mindmap" width="100%" height="100%">
+        <g id="viewport"></g>
+    </svg>
+    <div id="imageOverlay">
+        <img id="overlayImg" class="img-fluid" alt="Node image">
+    </div>
+    <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,5 +1,6 @@
-const NODE_W = 80;
-const NODE_H = 40;
+export const NODE_MIN_W = 80;
+export const NODE_TEXT_H = 24; // approximate height of one line
+export const NODE_PADDING = 10;
 const H_GAP = 60;
 const V_GAP = 20;
 
@@ -8,8 +9,11 @@ export function layout(map) {
 
     function measure(id) {
         const node = map.nodes[id];
-        node.w = NODE_W + (node.media ? node.media.width + 10 : 0);
-        node.h = Math.max(NODE_H, node.media ? node.media.height + 10 : NODE_H);
+        const textWidth = Math.max(node.text.length * 8 + NODE_PADDING * 2, NODE_MIN_W);
+        const mediaWidth = node.media ? node.media.width + NODE_PADDING * 2 : 0;
+        node.w = Math.max(textWidth, mediaWidth, NODE_MIN_W);
+        const mediaH = node.media ? node.media.height : 0;
+        node.h = NODE_PADDING * 2 + mediaH + (node.media ? NODE_PADDING : 0) + NODE_TEXT_H;
         if (!node.children.length) {
             heights[id] = node.h;
             return heights[id];
@@ -27,7 +31,7 @@ export function layout(map) {
 
     function place(id, depth, centerY) {
         const node = map.nodes[id];
-        node.x = depth * (NODE_W + H_GAP);
+        node.x = depth * (NODE_MIN_W + H_GAP);
         node.y = centerY - node.h / 2;
         if (!node.children.length) return;
         let total = 0;

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,60 @@
+const NODE_W = 80;
+const NODE_H = 40;
+const H_GAP = 60;
+const V_GAP = 20;
+
+export function layout(map) {
+    const heights = {};
+
+    function measure(id) {
+        const node = map.nodes[id];
+        node.w = NODE_W + (node.media ? node.media.width + 10 : 0);
+        node.h = Math.max(NODE_H, node.media ? node.media.height + 10 : NODE_H);
+        if (!node.children.length) {
+            heights[id] = node.h;
+            return heights[id];
+        }
+        let total = 0;
+        node.children.forEach(c => {
+            total += measure(c);
+        });
+        total += V_GAP * (node.children.length - 1);
+        heights[id] = Math.max(node.h, total);
+        return heights[id];
+    }
+
+    measure(map.rootId);
+
+    function place(id, depth, centerY) {
+        const node = map.nodes[id];
+        node.x = depth * (NODE_W + H_GAP);
+        node.y = centerY - node.h / 2;
+        if (!node.children.length) return;
+        let total = 0;
+        node.children.forEach(c => total += heights[c]);
+        total += V_GAP * (node.children.length - 1);
+        let start = centerY - total / 2;
+        node.children.forEach(c => {
+            const h = heights[c];
+            const childCenter = start + h / 2;
+            place(c, depth + 1, childCenter);
+            start += h + V_GAP;
+        });
+    }
+
+    place(map.rootId, 0, 0);
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    Object.values(map.nodes).forEach(n => {
+        minX = Math.min(minX, n.x);
+        minY = Math.min(minY, n.y);
+        maxX = Math.max(maxX, n.x + n.w);
+        maxY = Math.max(maxY, n.y + n.h);
+    });
+    const offsetX = -(minX + maxX) / 2;
+    const offsetY = -(minY + maxY) / 2;
+    Object.values(map.nodes).forEach(n => {
+        n.x += offsetX;
+        n.y += offsetY;
+    });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,284 @@
+import { createEmptyMap, addChild, addSibling, deleteNode, setNodeImage } from './model.js';
+import { layout } from './layout.js';
+import { render } from './render.js';
+
+let map = createEmptyMap();
+let selectedId = map.rootId;
+const viewport = document.getElementById('viewport');
+const overlay = document.getElementById('imageOverlay');
+const overlayImg = document.getElementById('overlayImg');
+
+let pan = {x:0, y:0, scale:1};
+
+function update() {
+    layout(map);
+    render(map, viewport, selectedId);
+    viewport.setAttribute('transform', `translate(${pan.x},${pan.y}) scale(${pan.scale})`);
+}
+update();
+
+// selection handling
+viewport.addEventListener('click', e => {
+    const img = e.target.closest('.node-image');
+    if (img) {
+        overlayImg.src = img.dataset.url;
+        overlay.style.display = 'flex';
+        return;
+    }
+    const g = e.target.closest('.node');
+    if (g) {
+        selectedId = g.dataset.id;
+        update();
+    }
+});
+
+// toolbar actions
+const addChildBtn = document.getElementById('addChildBtn');
+const addSiblingBtn = document.getElementById('addSiblingBtn');
+const deleteBtn = document.getElementById('deleteBtn');
+const newBtn = document.getElementById('newBtn');
+const fitBtn = document.getElementById('fitBtn');
+const imageBtn = document.getElementById('imageBtn');
+const saveBtn = document.getElementById('saveBtn');
+const loadBtn = document.getElementById('loadBtn');
+const imageInput = document.getElementById('imageInput');
+const loadInput = document.getElementById('loadInput');
+overlay.addEventListener('click', () => {
+    overlay.style.display = 'none';
+    overlayImg.src = '';
+});
+
+addChildBtn.onclick = () => {
+    const id = addChild(map, selectedId);
+    selectedId = id;
+    update();
+    startEditing(id);
+};
+
+addSiblingBtn.onclick = () => {
+    const id = addSibling(map, selectedId);
+    if (id) {
+        selectedId = id;
+        update();
+        startEditing(id);
+    }
+};
+
+deleteBtn.onclick = () => {
+    deleteNode(map, selectedId);
+    selectedId = map.rootId;
+    update();
+};
+
+newBtn.onclick = () => {
+    map = createEmptyMap();
+    selectedId = map.rootId;
+    pan = {x:0,y:0,scale:1};
+    update();
+    startEditing(selectedId);
+};
+
+imageBtn.onclick = () => {
+    imageInput.value = '';
+    imageInput.click();
+};
+
+imageInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => {
+        const img = new Image();
+        img.onload = () => {
+            const max = 128;
+            let w = img.width;
+            let h = img.height;
+            let scale = 1;
+            if (w > h && w > max) scale = max / w;
+            else if (h > w && h > max) scale = max / h;
+            w = Math.round(w * scale);
+            h = Math.round(h * scale);
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, w, h);
+            const dataUrl = canvas.toDataURL('image/png');
+            setNodeImage(map, selectedId, {
+                kind: 'image',
+                dataUrl,
+                width: w,
+                height: h,
+                naturalWidth: img.width,
+                naturalHeight: img.height
+            });
+            update();
+        };
+        img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
+});
+
+saveBtn.onclick = () => {
+    const json = JSON.stringify(map, null, 2);
+    const blob = new Blob([json], {type: 'application/json'});
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `${map.title}-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+};
+
+loadBtn.onclick = () => {
+    loadInput.value = '';
+    loadInput.click();
+};
+
+loadInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => {
+        try {
+            map = JSON.parse(ev.target.result);
+            selectedId = map.rootId;
+            pan = {x:0,y:0,scale:1};
+            update();
+        } catch (err) {
+            alert('Invalid JSON');
+        }
+    };
+    reader.readAsText(file);
+});
+
+fitBtn.onclick = fitToScreen;
+
+function fitToScreen() {
+    const bbox = viewport.getBBox();
+    const svg = document.getElementById('mindmap');
+    const w = svg.clientWidth;
+    const h = svg.clientHeight;
+    const scale = Math.min(w / (bbox.width + 40), h / (bbox.height + 40));
+    const tx = -bbox.x * scale + (w - bbox.width * scale) / 2;
+    const ty = -bbox.y * scale + (h - bbox.height * scale) / 2;
+    pan = { x: tx, y: ty, scale };
+    update();
+}
+
+// pan and zoom
+let isPanning = false;
+let start = {x:0,y:0};
+
+document.getElementById('mindmap').addEventListener('mousedown', e => {
+    isPanning = true;
+    start = { x: e.clientX - pan.x, y: e.clientY - pan.y };
+});
+
+document.addEventListener('mousemove', e => {
+    if (isPanning) {
+        pan.x = e.clientX - start.x;
+        pan.y = e.clientY - start.y;
+        update();
+    }
+});
+
+document.addEventListener('mouseup', () => {
+    isPanning = false;
+});
+
+document.getElementById('mindmap').addEventListener('wheel', e => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? -0.1 : 0.1;
+    pan.scale = Math.min(2, Math.max(0.25, pan.scale + delta));
+    update();
+});
+
+// keyboard shortcuts
+window.addEventListener('keydown', e => {
+    if (e.target.tagName === 'INPUT') return;
+    if (e.key === 'Escape' && overlay.style.display === 'flex') {
+        overlay.click();
+    } else if (e.key === 'Tab') {
+        e.preventDefault();
+        addChildBtn.onclick();
+    } else if (e.key === 'Enter') {
+        e.preventDefault();
+        addSiblingBtn.onclick();
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault();
+        deleteBtn.onclick();
+    } else if (e.key === 'f' && e.ctrlKey) {
+        e.preventDefault();
+        fitToScreen();
+    } else if (e.key === 'F2') {
+        e.preventDefault();
+        startEditing(selectedId);
+    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        startEditing(selectedId, e.key);
+        e.preventDefault();
+    }
+});
+
+// double click to edit
+viewport.addEventListener('dblclick', e => {
+    const g = e.target.closest('.node');
+    if (g) {
+        startEditing(g.dataset.id);
+    }
+});
+
+let editingInput = null;
+let editingId = null;
+
+function startEditing(id, initial) {
+    if (editingInput) return;
+    editingId = id;
+    const nodeEl = viewport.querySelector(`.node[data-id="${id}"]`);
+    if (!nodeEl) return;
+    const bbox = nodeEl.getBoundingClientRect();
+    editingInput = document.createElement('input');
+    editingInput.type = 'text';
+    editingInput.className = 'edit-input';
+    editingInput.value = initial !== undefined ? initial : map.nodes[id].text;
+    positionEditor(bbox);
+    document.body.appendChild(editingInput);
+    editingInput.focus();
+    if (initial === undefined) {
+        editingInput.select();
+    } else {
+        editingInput.setSelectionRange(editingInput.value.length, editingInput.value.length);
+    }
+    editingInput.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+            finishEditing();
+        }
+    });
+    editingInput.addEventListener('blur', finishEditing);
+}
+
+function positionEditor(bbox) {
+    if (!editingInput) return;
+    editingInput.style.left = bbox.x + 'px';
+    editingInput.style.top = bbox.y + 'px';
+    editingInput.style.width = bbox.width + 'px';
+    editingInput.style.height = bbox.height + 'px';
+}
+
+function finishEditing() {
+    if (!editingInput) return;
+    map.nodes[editingId].text = editingInput.value;
+    document.body.removeChild(editingInput);
+    editingInput = null;
+    editingId = null;
+    update();
+}
+
+// reposition editor on update
+const originalUpdate = update;
+update = function() {
+    originalUpdate();
+    if (editingInput && editingId) {
+        const nodeEl = viewport.querySelector(`.node[data-id="${editingId}"]`);
+        if (nodeEl) positionEditor(nodeEl.getBoundingClientRect());
+    }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -22,8 +22,8 @@ viewport.addEventListener('click', e => {
     const img = e.target.closest('.node-image');
     if (img) {
         overlayImg.src = img.dataset.url;
-        overlayImg.style.width = '';
-        overlayImg.style.height = '';
+        overlayImg.style.width = img.dataset.nw + 'px';
+        overlayImg.style.height = img.dataset.nh + 'px';
         overlay.style.display = 'flex';
         return;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -22,8 +22,8 @@ viewport.addEventListener('click', e => {
     const img = e.target.closest('.node-image');
     if (img) {
         overlayImg.src = img.dataset.url;
-        overlayImg.style.width = img.dataset.nw + 'px';
-        overlayImg.style.height = img.dataset.nh + 'px';
+        overlayImg.style.width = '';
+        overlayImg.style.height = '';
         overlay.style.display = 'flex';
         return;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -94,36 +94,23 @@ imageInput.addEventListener('change', e => {
     reader.onload = ev => {
         const img = new Image();
         img.onload = () => {
-            const storeMax = 256;
-            let w = img.width;
-            let h = img.height;
-            let scale = 1;
-            const longest = Math.max(w, h);
-            if (longest > storeMax) scale = storeMax / longest;
-            const storeW = Math.round(w * scale);
-            const storeH = Math.round(h * scale);
-            const canvas = document.createElement('canvas');
-            canvas.width = storeW;
-            canvas.height = storeH;
-            const ctx = canvas.getContext('2d');
-            ctx.drawImage(img, 0, 0, storeW, storeH);
-            const dataUrl = canvas.toDataURL('image/png');
+            const dataUrl = ev.target.result;
 
             // size inside the node
             const displayMax = 96;
             let dScale = 1;
-            const longestDisp = Math.max(storeW, storeH);
+            const longestDisp = Math.max(img.width, img.height);
             if (longestDisp > displayMax) dScale = displayMax / longestDisp;
-            const dispW = Math.round(storeW * dScale);
-            const dispH = Math.round(storeH * dScale);
+            const dispW = Math.round(img.width * dScale);
+            const dispH = Math.round(img.height * dScale);
 
             setNodeImage(map, selectedId, {
                 kind: 'image',
                 dataUrl,
                 width: dispW,
                 height: dispH,
-                naturalWidth: storeW,
-                naturalHeight: storeH
+                naturalWidth: img.width,
+                naturalHeight: img.height
             });
             update();
         };

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,8 @@ viewport.addEventListener('click', e => {
     const img = e.target.closest('.node-image');
     if (img) {
         overlayImg.src = img.dataset.url;
+        overlayImg.style.width = img.dataset.nw + 'px';
+        overlayImg.style.height = img.dataset.nh + 'px';
         overlay.style.display = 'flex';
         return;
     }
@@ -46,6 +48,8 @@ const loadInput = document.getElementById('loadInput');
 overlay.addEventListener('click', () => {
     overlay.style.display = 'none';
     overlayImg.src = '';
+    overlayImg.style.width = '';
+    overlayImg.style.height = '';
 });
 
 addChildBtn.onclick = () => {
@@ -90,27 +94,36 @@ imageInput.addEventListener('change', e => {
     reader.onload = ev => {
         const img = new Image();
         img.onload = () => {
-            const max = 128;
+            const storeMax = 256;
             let w = img.width;
             let h = img.height;
             let scale = 1;
-            if (w > h && w > max) scale = max / w;
-            else if (h > w && h > max) scale = max / h;
-            w = Math.round(w * scale);
-            h = Math.round(h * scale);
+            const longest = Math.max(w, h);
+            if (longest > storeMax) scale = storeMax / longest;
+            const storeW = Math.round(w * scale);
+            const storeH = Math.round(h * scale);
             const canvas = document.createElement('canvas');
-            canvas.width = w;
-            canvas.height = h;
+            canvas.width = storeW;
+            canvas.height = storeH;
             const ctx = canvas.getContext('2d');
-            ctx.drawImage(img, 0, 0, w, h);
+            ctx.drawImage(img, 0, 0, storeW, storeH);
             const dataUrl = canvas.toDataURL('image/png');
+
+            // size inside the node
+            const displayMax = 96;
+            let dScale = 1;
+            const longestDisp = Math.max(storeW, storeH);
+            if (longestDisp > displayMax) dScale = displayMax / longestDisp;
+            const dispW = Math.round(storeW * dScale);
+            const dispH = Math.round(storeH * dScale);
+
             setNodeImage(map, selectedId, {
                 kind: 'image',
                 dataUrl,
-                width: w,
-                height: h,
-                naturalWidth: img.width,
-                naturalHeight: img.height
+                width: dispW,
+                height: dispH,
+                naturalWidth: storeW,
+                naturalHeight: storeH
             });
             update();
         };

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,58 @@
+const PALETTE = ['#ff6f59', '#f6bd60', '#43aa8b', '#577590', '#d7263d', '#06d6a0'];
+
+export function createEmptyMap() {
+    const rootId = 'n1';
+    return {
+        id: 'map-' + Date.now(),
+        title: 'MindMap',
+        rootId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        version: 1,
+        colorIndex: 0,
+        nodes: {
+            [rootId]: { id: rootId, parentId: null, text: 'Root', children: [], color: '#ffffff' }
+        }
+    };
+}
+
+export function addChild(map, parentId) {
+    const id = 'n' + (Object.keys(map.nodes).length + 1);
+    let color = '#ffffff';
+    if (parentId === map.rootId) {
+        color = PALETTE[map.colorIndex % PALETTE.length];
+        map.colorIndex++;
+    } else {
+        color = map.nodes[parentId].color;
+    }
+    map.nodes[id] = { id, parentId, text: 'Node', children: [], color };
+    map.nodes[parentId].children.push(id);
+    map.updatedAt = Date.now();
+    return id;
+}
+
+export function addSibling(map, nodeId) {
+    const parentId = map.nodes[nodeId].parentId;
+    if (parentId === null) return null;
+    return addChild(map, parentId);
+}
+
+export function deleteNode(map, nodeId) {
+    const node = map.nodes[nodeId];
+    if (!node || nodeId === map.rootId) return;
+    const parent = map.nodes[node.parentId];
+    parent.children = parent.children.filter(id => id !== nodeId);
+    function removeSubtree(id) {
+        map.nodes[id].children.forEach(removeSubtree);
+        delete map.nodes[id];
+    }
+    removeSubtree(nodeId);
+    map.updatedAt = Date.now();
+}
+
+export function setNodeImage(map, nodeId, media) {
+    const node = map.nodes[nodeId];
+    if (!node) return;
+    if (media) node.media = media; else delete node.media;
+    map.updatedAt = Date.now();
+}

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,61 @@
+export function render(map, svg, selectedId) {
+    svg.innerHTML = '';
+    const linkGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    linkGroup.id = 'links';
+    svg.appendChild(linkGroup);
+    const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    nodeGroup.id = 'nodes';
+    svg.appendChild(nodeGroup);
+
+    // draw links
+    Object.values(map.nodes).forEach(node => {
+        if (node.parentId) {
+            const parent = map.nodes[node.parentId];
+            const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            line.classList.add('link');
+            line.setAttribute('x1', parent.x + parent.w);
+            line.setAttribute('y1', parent.y + parent.h / 2);
+            line.setAttribute('x2', node.x);
+            line.setAttribute('y2', node.y + node.h / 2);
+            linkGroup.appendChild(line);
+        }
+    });
+
+    // draw nodes
+    for (const id in map.nodes) {
+        const node = map.nodes[id];
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        g.classList.add('node');
+        g.setAttribute('data-id', id);
+        if (id === selectedId) g.classList.add('selected');
+        g.setAttribute('transform', `translate(${node.x},${node.y})`);
+
+        const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        rect.setAttribute('width', node.w);
+        rect.setAttribute('height', node.h);
+        if (node.color) rect.style.fill = node.color;
+        g.appendChild(rect);
+
+        let offset = 10;
+        if (node.media && node.media.kind === 'image') {
+            const img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+            img.classList.add('node-image');
+            img.dataset.url = node.media.dataUrl;
+            img.setAttribute('href', node.media.dataUrl);
+            img.setAttribute('width', node.media.width);
+            img.setAttribute('height', node.media.height);
+            img.setAttribute('x', 5);
+            img.setAttribute('y', (node.h - node.media.height) / 2);
+            g.appendChild(img);
+            offset += node.media.width + 5;
+        }
+
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', offset);
+        text.setAttribute('y', node.h / 2 + 5);
+        text.textContent = node.text;
+        g.appendChild(text);
+
+        nodeGroup.appendChild(g);
+    }
+}

--- a/src/render.js
+++ b/src/render.js
@@ -1,3 +1,5 @@
+import { NODE_PADDING, NODE_TEXT_H } from './layout.js';
+
 export function render(map, svg, selectedId) {
     svg.innerHTML = '';
     const linkGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -36,23 +38,27 @@ export function render(map, svg, selectedId) {
         if (node.color) rect.style.fill = node.color;
         g.appendChild(rect);
 
-        let offset = 10;
+        let cursorY = NODE_PADDING;
         if (node.media && node.media.kind === 'image') {
             const img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
             img.classList.add('node-image');
             img.dataset.url = node.media.dataUrl;
+            img.dataset.nw = node.media.naturalWidth;
+            img.dataset.nh = node.media.naturalHeight;
             img.setAttribute('href', node.media.dataUrl);
             img.setAttribute('width', node.media.width);
             img.setAttribute('height', node.media.height);
-            img.setAttribute('x', 5);
-            img.setAttribute('y', (node.h - node.media.height) / 2);
+            img.setAttribute('x', (node.w - node.media.width) / 2);
+            img.setAttribute('y', cursorY);
             g.appendChild(img);
-            offset += node.media.width + 5;
+            cursorY += node.media.height + NODE_PADDING;
         }
 
         const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-        text.setAttribute('x', offset);
-        text.setAttribute('y', node.h / 2 + 5);
+        text.setAttribute('x', node.w / 2);
+        text.setAttribute('y', cursorY + NODE_TEXT_H / 2);
+        text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('dominant-baseline', 'middle');
         text.textContent = node.text;
         g.appendChild(text);
 

--- a/src/render.js
+++ b/src/render.js
@@ -13,13 +13,16 @@ export function render(map, svg, selectedId) {
     Object.values(map.nodes).forEach(node => {
         if (node.parentId) {
             const parent = map.nodes[node.parentId];
-            const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-            line.classList.add('link');
-            line.setAttribute('x1', parent.x + parent.w);
-            line.setAttribute('y1', parent.y + parent.h / 2);
-            line.setAttribute('x2', node.x);
-            line.setAttribute('y2', node.y + node.h / 2);
-            linkGroup.appendChild(line);
+            const x1 = parent.x + parent.w;
+            const y1 = parent.y + parent.h / 2;
+            const x2 = node.x;
+            const y2 = node.y + node.h / 2;
+            const mid = (x1 + x2) / 2;
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.classList.add('link');
+            path.setAttribute('d', `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`);
+            path.setAttribute('fill', 'none');
+            linkGroup.appendChild(path);
         }
     });
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,63 @@
+body, html {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    font-family: sans-serif;
+}
+#toolbar {
+    padding: 4px;
+    background: #f8f9fa;
+    border-bottom: 1px solid #ccc;
+}
+#mindmap {
+    width: 100%;
+    height: calc(100% - 48px);
+    cursor: grab;
+}
+.node rect {
+    fill: #fff;
+    stroke: #333;
+    rx: 6;
+    ry: 6;
+}
+.node text {
+    pointer-events: none;
+    font-size: 14px;
+}
+.node.selected rect {
+    stroke: #ff6f59;
+    stroke-width: 2px;
+}
+
+.link {
+    stroke: #888;
+    stroke-width: 1.5px;
+}
+
+.edit-input {
+    position: absolute;
+    font-size: 14px;
+    box-sizing: border-box;
+    border: 1px solid #333;
+    padding: 2px;
+}
+.node-image {
+    cursor: pointer;
+}
+#imageOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+#imageOverlay img {
+    max-width: 90%;
+    max-height: 90%;
+    box-shadow: 0 0 10px #000;
+}

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,8 @@ body, html {
 .link {
     stroke: #888;
     stroke-width: 1.5px;
+    stroke-linecap: round;
+    fill: none;
 }
 
 .edit-input {
@@ -57,7 +59,7 @@ body, html {
     z-index: 1000;
 }
 #imageOverlay img {
-    max-width: 90%;
-    max-height: 90%;
+    max-width: 95%;
+    max-height: 95%;
     box-shadow: 0 0 10px #000;
 }


### PR DESCRIPTION
## Summary
- style toolbar with Bootstrap
- show node images in a fullscreen overlay on click
- allow closing the overlay with Escape
- document image popup and styling in README
- fix image overlay visibility

## Testing
- `node -c src/main.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c369c06bc832aa8534b7e85de47b4